### PR TITLE
Add CI to build Linux binaries

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,18 @@
+github: HarmonyHoney
+ko_fi: hhoney
+custom:
+  - https://hhoneysoft.itch.io/
+  - https://store.steampowered.com/publisher/HarmonyHoney
+  - https://www.youtube.com/@hhoney7
+
+# Unused by keeping here as a reminder
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username

--- a/.github/workflows/godot-linux.yml
+++ b/.github/workflows/godot-linux.yml
@@ -1,0 +1,61 @@
+name: "Godot Linux"
+on:
+  workflow_dispatch:
+  pull_request:
+  release:
+    types:
+      - released
+
+env:
+  GODOT_VERSION: 3.6
+  EXPORT_NAME: rota-linux
+
+jobs:
+  export:
+    name: Export
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/smks/godot-ci:3.6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up export templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/templates/
+          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+
+      - name: Export
+        run: |
+          mkdir --verbose --parents ./export/linux
+          godot --no-window --path=./project.godot --export "Linux/X11" ./export/linux/${EXPORT_NAME}.x86_64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+          path: |
+            export/linux/${{ env.EXPORT_NAME }}.x86_64
+            export/linux/${{ env.EXPORT_NAME }}.pck
+
+  release:
+    name: Release
+    needs: export
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+
+      - name: Display downloaded files
+        run: ls -R
+
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload '${{ github.ref_name }}' * --repo '${{ github.repository }}'

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -54,4 +54,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           tar -cJf ${{ env.EXPORT_NAME }}.tar.xz ${{ env.EXPORT_NAME }}.pck
-          gh release upload '${{ github.ref_name }}' ${{ env.EXPORT_NAME }}.tar.xz --repo '${{ github.repository }}'
+          gh release upload '${{ github.ref_name }}' * --repo '${{ github.repository }}'

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: >-
+        run: |
           tar -cJf ${{ env.EXPORT_NAME }}.tar.xz ${{ env.EXPORT_NAME }}.pck
           gh release upload '${{ github.ref_name }}' ${{ env.EXPORT_NAME }}.tar.xz --repo '${{ github.repository }}'

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -1,4 +1,4 @@
-name: "Godot Linux"
+name: "Godot Engine"
 on:
   workflow_dispatch:
   pull_request:
@@ -30,15 +30,13 @@ jobs:
       - name: Export
         run: |
           mkdir --verbose --parents ./export/linux
-          godot --no-window --path=./project.godot --export "Linux/X11" ./export/linux/${EXPORT_NAME}.x86_64
+          godot --no-window --path=./project.godot --export-pack "Linux/X11" ./export/linux/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}
-          path: |
-            export/linux/${{ env.EXPORT_NAME }}.x86_64
-            export/linux/${{ env.EXPORT_NAME }}.pck
+          path: export/linux/${{ env.EXPORT_NAME }}.pck
 
   release:
     name: Release
@@ -51,11 +49,9 @@ jobs:
         with:
           name: ${{ env.EXPORT_NAME }}
 
-      - name: Display downloaded files
-        run: ls -R
-
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
-          gh release upload '${{ github.ref_name }}' * --repo '${{ github.repository }}'
+          tar -cJf ${{ env.EXPORT_NAME }}.tar.xz ${{ env.EXPORT_NAME }}.pck
+          gh release upload '${{ github.ref_name }}' ${{ env.EXPORT_NAME }}.tar.xz --repo '${{ github.repository }}'

--- a/project.godot
+++ b/project.godot
@@ -185,7 +185,6 @@ Steam="*res://addons/steam_api/steam.gd"
 
 window/size/width=1280
 window/size/height=720
-window/size/borderless=true
 window/size/test_width=1920
 window/size/test_height=1080
 window/stretch/mode="2d"


### PR DESCRIPTION
This adds CI to publish Linux builds. How it works:

- Export ROTA for Linux from source using the Godot Engine CLI
- Upload that export to the CI run as a build artifact (which has a maximum lifetime of 90 days)
- On GitHub releases, attach that build artifact to the release (which has a permanent URL)

Building a Flatpak requires the exported `.pck` file be accessible to flatpak-builder, e.g. at a well-known URL, hence why we use releases instead of the build artifact directly—we want that URL to remain accessible to support reproducible builds. My personal goal is to get ROTA onto [Flathub](https://flathub.org/about). :)

A few notes:

1. I intended to use the [godot-ci GitHub Action](https://github.com/marketplace/actions/godot-ci) for CI, but it doesn't currently support Godot 3.6 (see: https://github.com/abarichello/godot-ci/issues/155). So for now, I'm using [docker.io/smks/godot-ci](https://hub.docker.com/r/smks/godot-ci) which is a container image forked from the former and just updated for 3.6.

2.  I changed the default project setting of `borderless` back to `false` to default to having window controls on Linux; this is the more expected behavior and recommended by Flathub's Quality Guidelines, though I could revert that and just patch it for the Flatpak itself if preferred.

3. I _think_ this CI could be expanded to also build artifacts of the Windows and HTML5 versions of the game, if that's of interest. I know it's not really necessary since the game is deployed to Itch.io which handles that, too, but I figured I'd mention it.