### PR TITLE
Flatpak: update MetaInfo with historical release notes

### DIFF
--- a/flatpak/metainfo.xml
+++ b/flatpak/metainfo.xml
@@ -63,7 +63,12 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.10" date="2024-12-06T21:44:45Z">
+    <release version="2024.12.10" date="2024-12-10">
+      <description>
+        <p>touch screen revisions</p>
+      </description>
+    </release>
+    <release version="2024.12.6" date="2024-12-06T21:44:45Z">
       <description>
         <p>New Logos &amp; Touch Screen Saving</p>
         <ul>

--- a/flatpak/metainfo.xml
+++ b/flatpak/metainfo.xml
@@ -63,6 +63,16 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.10" date="2024-12-06T21:44:45Z">
+      <description>
+        <p>New Logos &amp; Touch Screen Saving</p>
+        <ul>
+          <li>add new HHoney Software Logos</li>
+          <li>"Touch Screen" option will now save and load between game sessions</li>
+        </ul>
+        <p>(:</p>
+      </description>
+    </release>
     <release version="1.9" date="2024-09-09T23:08:11Z">
       <description>
         <p>Patch 9 - Android Port &amp; Touch Controls !</p>

--- a/flatpak/metainfo.xml
+++ b/flatpak/metainfo.xml
@@ -22,9 +22,11 @@
   </description>
   <id>net.hhoney.rota</id>
   <launchable type="desktop-id">net.hhoney.rota.desktop</launchable>
-  <metadata_license>CC0</metadata_license>
+  <metadata_license>Unlicense</metadata_license>
   <project_license>Unlicense</project_license>
-  <content_rating type="oars-1.1"></content_rating>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">mild</content_attribute>
+  </content_rating>
   <url type="homepage">https://hhoney.net</url>
   <url type="bugtracker">https://github.com/HarmonyHoney/ROTA/issues</url>
   <url type="donation">https://ko-fi.com/hhoney</url>
@@ -61,7 +63,146 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="0.0.0" date="2024-12-03" />
+    <release version="1.9" date="2024-09-09T23:08:11Z">
+      <description>
+        <p>Patch 9 - Android Port &amp; Touch Controls !</p>
+        <ul>
+          <li>ROTA on Android</li>
+          <li>Touch Controls for any device</li>
+          <li>Adjust Touch Control Margins</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.8" date="2024-09-09T23:08:11Z">
+      <description>
+        <p>Patch 8 - New Logo &amp; Engine Upgrade</p>
+        <ul>
+          <li>Game Engine update from Godot 3.5.2 to Godot 3.6</li>
+          <li>New Logo !</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.7" date="2023-05-27T05:42:05Z">
+      <description>
+        <p>Patch 7 - Arcade Action &amp; Ultrawide Support</p>
+        <ul>
+          <li>"Wrap It Up" Arcade Cabinet located in the Grasslands (:</li>
+          <li>Ultrawide Display Support! ROTA now expands to infinite width...</li>
+          <li>Weather is silent when Disabled</li>
+          <li>Weather Volume Option</li>
+        </ul>
+        <p>New Achievements:</p>
+        <ul>
+          <li>Shiny - Collect your first Gem</li>
+          <li>Fast Fingers - Collect your first Clock</li>
+          <li>Clock Collector - Collect 50 Clocks (=</li>
+          <li>Wrap It Up - Clear the First Loop</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.6" date="2023-04-21T17:57:17Z">
+      <description>
+        <p>Patch 6 - High Refresh Rate Support! (=</p>
+        <p>This update brings two new Options in the Menu:</p>
+        <ul>
+          <li>Interpolation</li>
+          <li>Frame Limit</li>
+        </ul>
+        <p>Interpolation will smooth out player movement on higher refresh rate displays! Frame limit can limit the maximum Frames Per Second of the game (:</p>
+        <p>Thanks to the pull request by neropatti! &lt;3</p>
+      </description>
+      <issues>
+        <issue url="https://github.com/HarmonyHoney/ROTA/pull/1">Add smoothing/interpolation to player visuals</issue>
+      </issues>
+    </release>
+    <release version="1.5" date="2023-04-17T22:42:29Z">
+      <description>
+        <p>Breath of Life Update - Patch 5</p>
+        <p>New friends have arrived in ROTA! The Sun, Moon and Stars have come along with them... ROTA is now populated with curious characters eager to meet you! Have a chat between puzzles! Clouds have filled with sky, bringing weather like rain and snow falling gently to the ground.</p>
+        <p>Changes:</p>
+        <ul>
+          <li>New Characters moved in, populating ROTA!</li>
+          <li>Chat with folks and get to know them (;</li>
+          <li>Connect stray worlds and bring people together!</li>
+        </ul>
+        <ul>
+          <li>Dynamic Weather System! Clouds fill the sky with falling Rain &amp; Snow...</li>
+          <li>Day &amp; Night! Watch the Sun rise and Moon fall.</li>
+          <li>Dynamic Lighting and Shadows! Illuminated by the Burning Star in Orbit.</li>
+          <li>Stars come out at night! Twinkling in the distance...</li>
+          <li>Background depth with Parallax layers!</li>
+        </ul>
+        <ul>
+          <li>Doors hold a Vortex, sucking in travelers and spitting them out the other end!</li>
+          <li>Door closing Sound Effect.</li>
+          <li>World Door Unlock Cutscene! Combine the power of Gems and fill the socket...</li>
+        </ul>
+        <ul>
+          <li>All Menus overhauled! Simple &amp; Clean.</li>
+          <li>Pause Menu minified. The world keeps moving...</li>
+          <li>UI animation improved when collecting a Gem or Clock!</li>
+          <li>Hair physics rework! Smoother motions when swaying in the breeze (;</li>
+          <li>Radial Blur effect with help from Guy Unger! &lt;3</li>
+        </ul>
+        <ul>
+          <li>Player D-Pad &amp; Joystick input issues fixed! Movement feels more responsive.</li>
+          <li>Camera speed V-Sync issue fixed!</li>
+          <li>Performance improvements! Ignoring many objects off-screen.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.4" date="2023-01-07T09:00:46Z">
+      <description>
+        <p>Patch 4 - Character Creator and Speedruns!</p>
+        <p>Changes:</p>
+        <ul>
+          <li>Character Creator</li>
+          <li>Speedrun Goals!</li>
+          <li>Ending Scene</li>
+          <li>Visual Overhaul, More Animations and Polygons! (=</li>
+          <li>Input Responsiveness and Bugfixes</li>
+          <li>Performance Optimations! (;</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.3" date="2022-06-29T00:29:02Z">
+      <description>
+        <p>Patch 3 - Demo! (:</p>
+        <p>Hello everyone! ^.^ ROTA now has a free Demo!</p>
+        <p>Explore and solve the first 8 puzzles before you buy the game!</p>
+        <p>Cross-save is enabled, so any progress you make in the demo will carry over into the full game! (:</p>
+        <p>Have fun and keep on rotating! &lt;3</p>
+        <p>- Harmony Honey</p>
+      </description>
+    </release>
+    <release version="1.2" date="2022-05-29T09:43:38Z">
+      <description>
+        <p>Patch 2</p>
+        <ul>
+          <li>Fixed Gem placement on puzzle 3 in cobblestone.</li>
+          <li>Fixed a bug with the player riding boxes.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.1" date="2022-05-10T20:01:27Z">
+      <description>
+        <p>Patch 1</p>
+        <p>Hello everyone, Patch 1 is now live!</p>
+        <p>This build comes with two minor bug fixes:</p>
+        <ul>
+          <li>Menu scrolling re-worked</li>
+          <li>Prevent the player from riding on boxes moving upward</li>
+        </ul>
+        <p>Thanks for the feedback! Please let me know if you see anything funny.</p>
+        <p>Contact me on discord! (｡◕‿◕｡) Harmony &lt;3#8571</p>
+      </description>
+    </release>
+    <release version="1.0" date="2022-05-07T22:18:44Z">
+      <description>
+        <p>Launch Day!!</p>
+        <p>ROTA is out now!! Thank you all for the support and positivity! Every order on itch comes with a steam key on launch! (:</p>
+      </description>
+    </release>
   </releases>
   <supports>
     <control>touch</control>


### PR DESCRIPTION
These came from the [Itch devlog](https://hhoneysoftware.itch.io/rota/devlog), lightly adapted for the limited HTML-like release notes format for MetaInfo.