### PR TITLE
Flatpak: add supported input devices to metainfo

### DIFF
--- a/export/flatpak/metainfo.xml
+++ b/export/flatpak/metainfo.xml
@@ -63,4 +63,11 @@
   <releases>
     <release version="0.0.0" date="2024-12-03" />
   </releases>
+  <supports>
+    <control>touch</control>
+  </supports>
+  <recommends>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </recommends>
 </component>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control

I have always found this spec confusing but I think this change correctly encodes that either keyboard or gamepad is recommended, but if you have neither touchscreen input is supported (though it happens to be off by default).