### PR TITLE
Flatpak: update manifest to match Flathub version

### DIFF
--- a/net.hhoney.rota.json
+++ b/net.hhoney.rota.json
@@ -10,7 +10,7 @@
     "--share=ipc",
     "--socket=x11",
     "--socket=pulseaudio",
-    "--device=dri"
+    "--device=all"
   ],
   "modules": [
     {
@@ -18,17 +18,16 @@
       "buildsystem": "simple",
       "sources": [
         {
-          "type": "file",
-          "url": "https://github.com/cassidyjames/ROTA/releases/download/0.0.10/rota-linux.pck",
-          "sha256": "603fc222d6b163cc332c0e1273c4f9b063236782ccef8dfcf0f8dc3aeaf1bb8d"
-        },
-        {
           "type": "dir",
           "path": "."
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/HarmonyHoney/ROTA/releases/download/Flathub/rota-linux.pck",
+          "sha256": "be8d360457c89895093d6799ab4e1d3944a7a9612faccd18f02b48bbc7694b58"
         }
       ],
       "build-commands": [
-        "ls -a",
         "install -Dm644 rota-linux.pck ${FLATPAK_DEST}/bin/godot-runner.pck",
         "install -Dm644 export/flatpak/launcher.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
         "install -Dm644 export/flatpak/metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml",


### PR DESCRIPTION
This matches the manifest at https://github.com/flathub/net.hhoney.rota/blob/master/net.hhoney.rota.json with one exception: it points to the local directory instead of the git repository, so you can use it to test changes locally or in CI.

Summary of changes:
- Expands the device permission to all devices to support gamepads
- References the exported PCK file from the upstream repo's release
- Removes an accidentally-left-in debugging line