### PR TITLE
Re-add Flatpak export

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -1,0 +1,57 @@
+name: "Godot Engine"
+on:
+  workflow_dispatch:
+  pull_request:
+  release:
+    types:
+      - released
+
+env:
+  GODOT_VERSION: 3.6
+  EXPORT_NAME: ROTA
+
+jobs:
+  export:
+    name: Export
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/smks/godot-ci:3.6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up export templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/templates/
+          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+
+      - name: Export
+        run: |
+          mkdir --verbose --parents ./export/linux
+          godot --no-window --path=./project.godot --export-pack "Linux/X11" ./export/linux/${EXPORT_NAME}.pck
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+          path: export/linux/${{ env.EXPORT_NAME }}.pck
+
+  release:
+    name: Release
+    needs: export
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          tar -cJf ${{ env.EXPORT_NAME }}.tar.xz ${{ env.EXPORT_NAME }}.pck
+          gh release upload '${{ github.ref_name }}' * --repo '${{ github.repository }}'

--- a/export/flatpak/launcher.desktop
+++ b/export/flatpak/launcher.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=ROTA
+GenericName=Puzzle Game
+Comment=Gravity bends beneath your feet
+Exec=godot-runner
+Icon=net.hhoney.rota
+Terminal=false
+Type=Application
+Categories=Game;KidsGame;

--- a/export/flatpak/metainfo.xml
+++ b/export/flatpak/metainfo.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>ROTA</name>
+  <summary>Gravity bends beneath your feet</summary>
+  <branding>
+    <color type="primary" scheme_preference="light">#ff99ff</color>
+    <color type="primary" scheme_preference="dark">#850087</color>
+  </branding>
+  <developer_name translatable="no">HHoney Software</developer_name>
+  <developer id="net.hhoney">
+    <name translatable="no">HHoney Software</name>
+  </developer>
+  <description>
+    <p>Move blocks and twist gravity to solve puzzles. Collect all 50 gems and explore 8 vibrant worlds.</p>
+    <ul>
+      <li>Rotate gravity as you walk over the edge!</li>
+      <li>Push, pull and rotate gravity-blocks to traverse the stage and solve puzzles.</li>
+      <li>Collect all 50 gems to unlock doors and explore 8 vibrant worlds!</li>
+      <li>Listen to an original ambient soundtrack that will keep you relaxed while solving challenging puzzles. (:</li>
+      <li>Watch out for spikes! 0:</li>
+    </ul>
+  </description>
+  <id>net.hhoney.rota</id>
+  <launchable type="desktop-id">net.hhoney.rota.desktop</launchable>
+  <metadata_license>CC0</metadata_license>
+  <project_license>Unlicense</project_license>
+  <content_rating type="oars-1.1"></content_rating>
+  <url type="homepage">https://hhoney.net</url>
+  <url type="bugtracker">https://github.com/HarmonyHoney/ROTA/issues</url>
+  <url type="donation">https://ko-fi.com/hhoney</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/1.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/2.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/3.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/4.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/5.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/6.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/7.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/8.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/9.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/HarmonyHoney/ROTA/6c7dafea0993700258f77a2412eef7fca5fa559c/media/image/assets/screens/10.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.0.0" date="2024-12-03" />
+  </releases>
+</component>

--- a/net.hhoney.rota.json
+++ b/net.hhoney.rota.json
@@ -1,0 +1,38 @@
+{
+  "id": "net.hhoney.rota",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "24.08",
+  "base": "org.godotengine.godot.BaseApp",
+  "base-version": "3.6",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "godot-runner",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=pulseaudio",
+    "--device=all"
+  ],
+  "modules": [
+    {
+      "name": "rota",
+      "buildsystem": "simple",
+      "sources": [
+        {
+          "type": "dir",
+          "path": "."
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/HarmonyHoney/ROTA/releases/download/something/ROTA.pck",
+          "sha256": "a89741f56eb6282d703f81f907617f6cb86caf66a78fce94d48fb5ddfd65305c"
+        }
+      ],
+      "build-commands": [
+        "install -Dm644 ROTA.pck ${FLATPAK_DEST}/bin/godot-runner.pck",
+        "install -Dm644 export/flatpak/launcher.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
+        "install -Dm644 export/flatpak/metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml",
+        "install -Dm644 media/image/icon/icon256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Re-add .desktop file for a launcher on Linux
- [x] Re-add metainfo.xml for the app listing on Flathub
- [x] Re-add the manifest, pointing at the latest release for the .pck file
- [x] Re-add .pck export in CI