### PR TITLE
metainfo: update release info for Flathub

### DIFF
--- a/linux/net.hhoney.rota.metainfo.xml
+++ b/linux/net.hhoney.rota.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <name>ROTA: Bend Gravity</name>
+  <name>ROTA</name>
   <summary>Gravity bends beneath your feet</summary>
   <branding>
     <color type="primary" scheme_preference="light">#ffc3d6</color>
@@ -8,7 +8,7 @@
   </branding>
   <developer_name translatable="no">Harmony Monroe and Friends</developer_name>
   <developer id="net.hhoney">
-    <name translatable="no">HHoney Software</name>
+    <name translatable="no">Harmony Monroe and Friends</name>
   </developer>
   <description>
     <p>Move blocks and twist gravity to solve puzzles. Collect all 50 gems and explore 8 vibrant worlds.</p>

--- a/linux/net.hhoney.rota.releases.xml
+++ b/linux/net.hhoney.rota.releases.xml
@@ -1,4 +1,7 @@
 <releases>
+  <release version="2026.03.11" date="2026-03-11">
+    <p>Updated Flathub listing</p>
+  </release>
   <release version="2025.08.18" date="2025-08-18">
     <description>
       <p>Soundtrack Update</p>


### PR DESCRIPTION
~~Added the missed developer tag and reverted the title to follow the [Flathub guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#just-the-name).~~ Also updated the releases file so we can make a new release for Flathub.