### PR TITLE
linux: Update Godot Engine and Flatpak versions

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,11 +13,11 @@ jobs:
   flatpak:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
       options: --privileged
     steps:
-    - uses: actions/checkout@v4
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: actions/checkout@v7.0.0
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.7
       with:
         bundle: rota.flatpak
         manifest-path: linux/net.hhoney.rota.yml

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -52,7 +52,7 @@ jobs:
           touch ._sc_
 
           # NOTE: export filename is relative to the project path
-          ./godot --no-window --path=./project.godot --export-pack "Linux/X11" ./export/${EXPORT_NAME}.pck
+          ./godot --no-window --path=.. --export-pack "Linux/X11" ./export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -7,36 +7,58 @@ on:
       - released
 
 env:
-  GODOT_VERSION: 3.6
+  GODOT_VERSION: 3.6.2
   EXPORT_NAME: rota-ci
 
 jobs:
   export:
     name: Export
     runs-on: ubuntu-latest
-    container:
-      image: docker.io/smks/godot-ci:3.6
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
+
+      - name: Cache Godot Engine downloads
+        id: cache-godot
+        uses: actions/cache@v4
         with:
-          lfs: true
+          path: |
+            export/godot
+            export/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
+          key: godot-${{ env.GODOT_VERSION }}
 
-      - name: Set up export templates
+      - name: Download Godot Engine from GitHub release
+        id: download
+        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
-          mkdir -v -p ~/.local/share/godot/templates/
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+          mkdir -p export && cd export
 
-      - name: Export
+          # Download Godot Engine itself
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip && \
+          unzip Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip && \
+          mv Godot_v${GODOT_VERSION}-stable_linux_headless.64 godot
+
+          # Download export templates
+          mkdir -p editor_data/export_templates
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
+
+      - name: Export PCK file
         run: |
-          mkdir --verbose --parents ./export/linux
-          godot --no-window --path=./project.godot --export-pack "Linux/X11" ./export/linux/${EXPORT_NAME}.pck
+          cd export
+
+          # Tell Godot Engine to be self-contained
+          touch ._sc_
+
+          # NOTE: export filename is relative to the project path
+          ./godot --no-window --path=./project.godot --export-pack "Linux/X11" ./export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ env.EXPORT_NAME }}
-          path: export/linux/${{ env.EXPORT_NAME }}.pck
+          path: export/${{ env.EXPORT_NAME }}.pck
 
   release:
     name: Release
@@ -45,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ env.EXPORT_NAME }}
 

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -46,13 +46,10 @@ jobs:
 
       - name: Export PCK file
         run: |
-          cd export
-
           # Tell Godot Engine to be self-contained
-          touch ._sc_
+          touch export/._sc_
 
-          # NOTE: export filename is relative to the project path
-          ./godot --no-window --path=.. --export-pack "Linux/X11" ./export/${EXPORT_NAME}.pck
+          export/godot --no-window --path=. --export-pack "Linux/X11" export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1


### PR DESCRIPTION
Godot Engine 3.6.2, fdo-sdk 25.08